### PR TITLE
Update pypuniprot __init__.py

### DIFF
--- a/pyproteome/pypuniprot/__init__.py
+++ b/pyproteome/pypuniprot/__init__.py
@@ -111,9 +111,9 @@ def prefetch_all_msf_uniprot():
             vals = cursor.execute(
                 '''
                 SELECT
-                ProteinAnnotations.Description
+                TargetProteins.FastaTitleLines
                 FROM
-                ProteinAnnotations
+                TargetProteins
                 '''
             )
 


### PR DESCRIPTION
Change UNIPROT fetch function to access TargetProteins within the .msf file since ProteinAnnotations is deprecated